### PR TITLE
Multiple OS support for clipboard and added a pathogen check

### DIFF
--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -42,6 +42,8 @@ nmap <silent> G  Gzz
 set cpo-=<
 set wcm=<C-Z>
 
-"Set up the clipboard to be shared across termi windows, note this might have
-"to change depending on what version of Vim and OS you are running."
-set clipboard+=unnamed
+"X System support for clipboard"
+if has('clipboard')
+  set clipboard=unnamed, unnamedplus
+endif
+


### PR DESCRIPTION
Universal approach for clipboard, so as it as long as Vim is compiled with clipboard, it will work.

Also suppressed a warning about Pathogen if it wasn't loaded.